### PR TITLE
Retry Packtory CI API steps

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -49,7 +49,19 @@ jobs:
               if: matrix.node-version == 24
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: npx just publish-dry-run
+              run: |
+                  for attempt in 1 2 3; do
+                      if npx just publish-dry-run; then
+                          exit 0
+                      fi
+
+                      status="$?"
+                      if [ "$attempt" -eq 3 ]; then
+                          exit "$status"
+                      fi
+
+                      sleep "$((attempt * 30))"
+                  done
             - name: Coveralls
               if: matrix.node-version == 24
               continue-on-error: true
@@ -166,4 +178,16 @@ jobs:
             - name: Maintain release pull request
               env:
                   GH_TOKEN: ${{ github.token }}
-              run: npx just prepare-release
+              run: |
+                  for attempt in 1 2 3; do
+                      if npx just prepare-release; then
+                          exit 0
+                      fi
+
+                      status="$?"
+                      if [ "$attempt" -eq 3 ]; then
+                          exit "$status"
+                      fi
+
+                      sleep "$((attempt * 30))"
+                  done


### PR DESCRIPTION
Packtory-driven CI steps call GitHub APIs while checking package output and maintaining the release PR. Retry those safe, idempotent commands so transient GitHub API failures like `502 Server Error`, `other side closed`, or a failed commit-status request do not fail `main` after the build and tests have already passed.