### PR TITLE
Update `@packtory/cli` to `0.0.89`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "@enormora/eslint-config-mocha-node-assert": "0.0.10",
                 "@enormora/eslint-config-node": "0.0.41",
                 "@enormora/eslint-config-typescript": "0.0.63",
-                "@packtory/cli": "0.0.86",
+                "@packtory/cli": "0.0.89",
                 "@types/common-tags": "1.8.4",
                 "@types/mocha": "10.0.10",
                 "@types/node": "24.13.3",
@@ -1529,17 +1529,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.13",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-            "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.0",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            }
-        },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -2044,9 +2033,9 @@
             }
         },
         "node_modules/@packtory/cli": {
-            "version": "0.0.86",
-            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.86.tgz",
-            "integrity": "sha512-MJYlTInyQNZgAKWaBTt64Dal6MimwRnpafhM7dTYBo2/l1GsGMWCCtVJ9pkl+fJT7ZxQjakfH8uJoL9qiA846w==",
+            "version": "0.0.89",
+            "resolved": "https://registry.npmjs.org/@packtory/cli/-/cli-0.0.89.tgz",
+            "integrity": "sha512-Xa3bgiHethAFxGzOZqF2ZQPkMYWuYv6ps9x1EG25F2bCaNhznk42top+VbBW2hUfizajZ+yBvuFZnh0O2jD0Gw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2057,7 +2046,7 @@
                 "cmd-ts": "0.15.0",
                 "diff": "9.0.0",
                 "open": "11.0.0",
-                "packtory": "0.0.76",
+                "packtory": "0.0.79",
                 "remeda": "2.39.0",
                 "semver": "7.8.5",
                 "ts-pattern": "5.9.0",
@@ -2229,9 +2218,9 @@
             }
         },
         "node_modules/@schema-hub/zod-error-formatter": {
-            "version": "0.0.14",
-            "resolved": "https://registry.npmjs.org/@schema-hub/zod-error-formatter/-/zod-error-formatter-0.0.14.tgz",
-            "integrity": "sha512-idk99FvWFX21Vs0jOcxVQEd7N8l1Veh7JlJHJLglw+enVO0HwPWYL2de588vdHE4Anonj7o4Du9bgVJZ+K+qnQ==",
+            "version": "0.0.15",
+            "resolved": "https://registry.npmjs.org/@schema-hub/zod-error-formatter/-/zod-error-formatter-0.0.15.tgz",
+            "integrity": "sha512-SEw4ygCq1l7v/WYzACqDUT15wv5YN/hMVwnSZD3jdlbiKwmz+aGnFEvUmE5O0SJjXacZlikCUkYkHq8mLFs4rw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3623,9 +3612,9 @@
             }
         },
         "node_modules/bare-url": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.1.tgz",
-            "integrity": "sha512-cD5ciQuKlx+eumTCfqbfiL+fhQm+dHbVNB/cX4+d+I/nx4JsVop9VoFEPAs5RJ6I84QR6bZIBjpd2kjDOYeWcg==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
+            "integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -9390,17 +9379,16 @@
             }
         },
         "node_modules/packtory": {
-            "version": "0.0.76",
-            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.76.tgz",
-            "integrity": "sha512-42cOEV4Yts9/eYTgz5wuUQ3tB3UumUxt0YAsecKxH1y207peTrEeK2fz5D6o3bss7uHB28XRctiaiv6E1lteuw==",
+            "version": "0.0.79",
+            "resolved": "https://registry.npmjs.org/packtory/-/packtory-0.0.79.tgz",
+            "integrity": "sha512-zYwL1nQGKCf6DRvJ9rgQUM09hzKhJcDUgKAd13kw+DO92VxidPtC9sBjI+0XFtGjL3GxGewEf5H+rnzPtFfBVg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@arethetypeswrong/core": "0.18.5",
                 "@cyclonedx/cyclonedx-library": "10.1.0",
-                "@jridgewell/gen-mapping": "0.3.13",
                 "@jridgewell/trace-mapping": "0.3.31",
-                "@schema-hub/zod-error-formatter": "0.0.14",
+                "@schema-hub/zod-error-formatter": "0.0.15",
                 "@ts-morph/common": "0.29.0",
                 "@types/npm-registry-fetch": "8.0.9",
                 "common-tags": "1.8.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "@enormora/eslint-config-mocha-node-assert": "0.0.10",
         "@enormora/eslint-config-node": "0.0.41",
         "@enormora/eslint-config-typescript": "0.0.63",
-        "@packtory/cli": "0.0.86",
+        "@packtory/cli": "0.0.89",
         "@types/common-tags": "1.8.4",
         "@types/mocha": "10.0.10",
         "@types/node": "24.13.3",


### PR DESCRIPTION
Updates `@packtory/cli` to `0.0.89`, which includes the upstream fix for release PR CI recursion from enormora/packtory#966. The lockfile is refreshed with npm 10 so CI can install it without package metadata drift.