### PR TITLE
Support Renovate group updates in `pr-log` collapse rules

### DIFF
--- a/packtory.config.js
+++ b/packtory.config.js
@@ -129,6 +129,11 @@ export async function buildConfig() {
                         label: 'upgrade',
                         pattern: '^⬆️ Update dependency (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$',
                         replace: '⬆️ Update dependency $<dependency> from $<from> to $<to>'
+                    },
+                    {
+                        label: 'upgrade',
+                        pattern: '^⬆️ (?<dependency>Lock file maintenance|Update .+ dependencies)(?<from>)(?<to>)$',
+                        replace: '⬆️ $<dependency>'
                     }
                 ]
             },


### PR DESCRIPTION
Extends the Packtory `pr-log` collapse configuration so repeated Renovate lock-file maintenance and grouped dependency update titles collapse into one changelog entry.

The new rule keeps versioned dependency update chaining separate and covers configured group names that use `⬆️ Update ... dependencies`.