### PR TITLE
Add `versionGroup` collapse rules

### DIFF
--- a/source/lib/create-changelog-highest-version-collapse.test.ts
+++ b/source/lib/create-changelog-highest-version-collapse.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert';
+import { createChangelogFactory } from './create-changelog.ts';
+import { createPrLogConfigFromPackageInfo } from './pr-log-config.ts';
+import { createVersionNumber } from './version-number.ts';
+
+test('collapses pull requests without from versions by highest captured version', function () {
+    const config = createPrLogConfigFromPackageInfo({
+        'pr-log': {
+            collapseRules: [
+                {
+                    label: 'upgrade',
+                    pattern: '^Update dependency (?<dependency>.+?) to (?<to>.+?)$',
+                    replace: 'Update dependency $<dependency> to $<to>',
+                    versionGroup: 'to'
+                }
+            ]
+        }
+    });
+    const createChangelog = createChangelogFactory({
+        getCurrentDate() {
+            return new Date(0);
+        },
+        config: {
+            ...config,
+            validLabels: new Map([ [ 'upgrade', 'Dependency Upgrades' ] ]),
+            versionBumps: { major: [], minor: [], patch: [ 'upgrade' ] }
+        }
+    });
+
+    const changelog = createChangelog({
+        unreleased: false,
+        versionNumber: createVersionNumber('1.0.0'),
+        githubRepo: 'any/repo',
+        mergedPullRequests: [
+            { id: 3, title: 'Update dependency @packtory/cli to v0.0.96', label: 'upgrade' },
+            { id: 4, title: 'Refresh dependency metadata', label: 'upgrade' },
+            { id: 2, title: 'Update dependency @packtory/cli to v0.0.97', label: 'upgrade' },
+            { id: 1, title: 'Update dependency @packtory/cli to v0.0.95', label: 'upgrade' }
+        ]
+    });
+
+    const expectedChangelog = [
+        '### Dependency Upgrades',
+        '',
+        '* Update dependency @packtory/cli to v0.0.97 ([#3](https://github.com/any/repo/pull/3), [#2](https://github.com/any/repo/pull/2), [#1](https://github.com/any/repo/pull/1))',
+        '* Refresh dependency metadata ([#4](https://github.com/any/repo/pull/4))',
+        ''
+    ]
+        .join('\n');
+
+    assert.ok(changelog.includes(expectedChangelog));
+});
+
+test('throws when a highest-version collapse rule matches a non-semver version', function () {
+    const createChangelog = createChangelogFactory({
+        getCurrentDate() {
+            return new Date(0);
+        },
+        config: createPrLogConfigFromPackageInfo({
+            'pr-log': {
+                collapseRules: [
+                    {
+                        label: 'upgrade',
+                        pattern: '^Update dependency (?<dependency>.+?) to (?<to>.+?)$',
+                        replace: 'Update dependency $<dependency> to $<to>',
+                        versionGroup: 'to'
+                    }
+                ]
+            }
+        })
+    });
+
+    assert.throws(
+        function () {
+            createChangelog({
+                unreleased: false,
+                versionNumber: createVersionNumber('1.0.0'),
+                githubRepo: 'any/repo',
+                mergedPullRequests: [
+                    { id: 1, title: 'Update dependency @packtory/cli to next', label: 'upgrade' }
+                ]
+            });
+        },
+        { message: 'Collapse rule for label "upgrade" requires semver capture group "to"' }
+    );
+});
+
+test('throws when a highest-version collapse rule is missing the version capture group', function () {
+    const createChangelog = createChangelogFactory({
+        getCurrentDate() {
+            return new Date(0);
+        },
+        config: createPrLogConfigFromPackageInfo({
+            'pr-log': {
+                collapseRules: [
+                    {
+                        label: 'upgrade',
+                        pattern: '^Update dependency (?<dependency>.+?)$',
+                        replace: 'Update dependency $<dependency> to $<to>',
+                        versionGroup: 'to'
+                    }
+                ]
+            }
+        })
+    });
+
+    assert.throws(
+        function () {
+            createChangelog({
+                unreleased: false,
+                versionNumber: createVersionNumber('1.0.0'),
+                githubRepo: 'any/repo',
+                mergedPullRequests: [
+                    { id: 1, title: 'Update dependency @packtory/cli', label: 'upgrade' }
+                ]
+            });
+        },
+        { message: 'Collapse rule for label "upgrade" requires capture group "to"' }
+    );
+});

--- a/source/lib/create-changelog.ts
+++ b/source/lib/create-changelog.ts
@@ -1,8 +1,14 @@
 import { format as formatDate } from 'date-fns';
 import { isArray } from '@sindresorhus/is';
 import { enUS as enLocale } from 'date-fns/locale/en-US';
+import semver from 'semver';
 import type { Just, Nothing } from 'true-myth/maybe';
-import type { CollapseRule, PrLogConfig } from './pr-log-config.ts';
+import type {
+    CollapseRule,
+    HighestVersionCollapseRule,
+    PrLogConfig,
+    VersionChainCollapseRule
+} from './pr-log-config.ts';
 import type { ChangelogEntryInput } from './render-changelog-markdown.ts';
 
 function formatLinkToPullRequest(pullRequestId: number, repo: string): string {
@@ -80,11 +86,20 @@ type RuleMatch = CollapseMatch & {
     readonly to: string;
 };
 
+type HighestVersionRuleMatch = CollapseMatch & {
+    readonly key: string;
+    readonly version: string;
+};
+
 type CollapseChain = {
     readonly firstIndex: number;
     readonly indexes: readonly number[];
     readonly groups: Readonly<Record<string, string>>;
     readonly pullRequestIds: readonly number[];
+};
+
+type HighestVersionCollapseGroup = CollapseChain & {
+    readonly version: string;
 };
 
 type CollapseChainUpdate = {
@@ -93,7 +108,7 @@ type CollapseChainUpdate = {
 };
 
 type CollapseChainContext = {
-    readonly rule: PrLogConfig['collapseRules'][number];
+    readonly rule: VersionChainCollapseRule;
     readonly ruleMatch: RuleMatch;
 };
 
@@ -107,14 +122,25 @@ function createChangelogEntries(pullRequests: readonly ChangelogEntryInput[]): r
     });
 }
 
-function getRuleGroups(match: CollapseMatch, rule: CollapseRule): Readonly<[string, string, string]> {
+function isHighestVersionCollapseRule(rule: CollapseRule): rule is HighestVersionCollapseRule {
+    return Object.hasOwn(rule, 'versionGroup');
+}
+
+function getRuleKey(match: CollapseMatch, rule: CollapseRule): string {
     const key = match.groups[rule.keyGroup];
-    const from = match.groups[rule.fromGroup];
-    const to = match.groups[rule.toGroup];
 
     if (key === undefined) {
         throw new TypeError(`Collapse rule for label "${rule.label}" requires capture group "${rule.keyGroup}"`);
     }
+
+    return key;
+}
+
+function getRuleGroups(match: CollapseMatch, rule: VersionChainCollapseRule): Readonly<[string, string, string]> {
+    const key = getRuleKey(match, rule);
+    const from = match.groups[rule.fromGroup];
+    const to = match.groups[rule.toGroup];
+
     if (from === undefined) {
         throw new TypeError(`Collapse rule for label "${rule.label}" requires capture group "${rule.fromGroup}"`);
     }
@@ -125,13 +151,33 @@ function getRuleGroups(match: CollapseMatch, rule: CollapseRule): Readonly<[stri
     return [ key, from, to ];
 }
 
+function getSemverGroup(match: CollapseMatch, rule: HighestVersionCollapseRule): string {
+    const version = match.groups[rule.versionGroup];
+
+    if (version === undefined) {
+        throw new TypeError(`Collapse rule for label "${rule.label}" requires capture group "${rule.versionGroup}"`);
+    }
+
+    const parsedVersion = semver.coerce(version);
+    if (parsedVersion === null) {
+        throw new TypeError(
+            `Collapse rule for label "${rule.label}" requires semver capture group "${rule.versionGroup}"`
+        );
+    }
+
+    return parsedVersion.version;
+}
+
 function renderCollapsedTitle(replace: string, groups: Readonly<Record<string, string>>): string {
     return replace.replaceAll(/\$<(?<groupName>[^>]+)>/gu, function (_match, groupName: string) {
         return groups[groupName] ?? '';
     });
 }
 
-function getRuleMatch(entry: ChangelogEntryWithLabel, rule: CollapseRule): RuleMatch | undefined {
+function getVersionChainRuleMatch(
+    entry: ChangelogEntryWithLabel,
+    rule: VersionChainCollapseRule
+): RuleMatch | undefined {
     const match = rule.pattern.exec(entry.title);
 
     if (match?.groups === undefined) {
@@ -141,6 +187,23 @@ function getRuleMatch(entry: ChangelogEntryWithLabel, rule: CollapseRule): RuleM
     const [ key, from, to ] = getRuleGroups({ groups: match.groups }, rule);
 
     return { key, from, to, groups: { ...match.groups } };
+}
+
+function getHighestVersionRuleMatch(
+    entry: ChangelogEntryWithLabel,
+    rule: HighestVersionCollapseRule
+): HighestVersionRuleMatch | undefined {
+    const match = rule.pattern.exec(entry.title);
+
+    if (match?.groups === undefined) {
+        return undefined;
+    }
+
+    const groups = { ...match.groups };
+    const key = getRuleKey({ groups }, rule);
+    const version = getSemverGroup({ groups }, rule);
+
+    return { key, version, groups };
 }
 
 function createExtendedChain(
@@ -199,9 +262,9 @@ function createUpdatedChainsByKey(
     chainsByKey: ReadonlyMap<string, readonly CollapseChain[]>,
     entry: ChangelogEntryWithLabel,
     index: number,
-    rule: CollapseRule
+    rule: VersionChainCollapseRule
 ): ReadonlyMap<string, readonly CollapseChain[]> {
-    const ruleMatch = getRuleMatch(entry, rule);
+    const ruleMatch = getVersionChainRuleMatch(entry, rule);
 
     if (ruleMatch === undefined) {
         return chainsByKey;
@@ -217,11 +280,71 @@ function createUpdatedChainsByKey(
 
 function createChainsByKey(
     entries: readonly ChangelogEntryWithLabel[],
-    rule: CollapseRule
+    rule: VersionChainCollapseRule
 ): ReadonlyMap<string, readonly CollapseChain[]> {
     return entries.reduce<ReadonlyMap<string, readonly CollapseChain[]>>(function (chainsByKey, entry, index) {
         return createUpdatedChainsByKey(chainsByKey, entry, index, rule);
     }, new Map<string, readonly CollapseChain[]>());
+}
+
+function createHighestVersionCollapseGroup(
+    index: number,
+    entry: ChangelogEntryWithLabel,
+    ruleMatch: HighestVersionRuleMatch
+): HighestVersionCollapseGroup {
+    return {
+        ...createCollapseChain(index, entry, ruleMatch.groups),
+        version: ruleMatch.version
+    };
+}
+
+function extendHighestVersionCollapseGroup(
+    group: HighestVersionCollapseGroup,
+    entry: ChangelogEntryWithLabel,
+    index: number,
+    ruleMatch: HighestVersionRuleMatch
+): HighestVersionCollapseGroup {
+    const highestVersionGroups = semver.gt(ruleMatch.version, group.version) ? ruleMatch.groups : group.groups;
+    const highestVersion = semver.gt(ruleMatch.version, group.version) ? ruleMatch.version : group.version;
+
+    return {
+        ...group,
+        indexes: [ ...group.indexes, index ],
+        groups: highestVersionGroups,
+        version: highestVersion,
+        pullRequestIds: [ ...group.pullRequestIds, ...entry.pullRequestIds ]
+    };
+}
+
+function updateHighestVersionGroupsByKey(
+    groupsByKey: ReadonlyMap<string, HighestVersionCollapseGroup>,
+    entry: ChangelogEntryWithLabel,
+    index: number,
+    rule: HighestVersionCollapseRule
+): ReadonlyMap<string, HighestVersionCollapseGroup> {
+    const ruleMatch = getHighestVersionRuleMatch(entry, rule);
+
+    if (ruleMatch === undefined) {
+        return groupsByKey;
+    }
+
+    const nextGroupsByKey = new Map(groupsByKey);
+    const group = groupsByKey.get(ruleMatch.key);
+    const nextGroup = group === undefined
+        ? createHighestVersionCollapseGroup(index, entry, ruleMatch)
+        : extendHighestVersionCollapseGroup(group, entry, index, ruleMatch);
+
+    nextGroupsByKey.set(ruleMatch.key, nextGroup);
+    return nextGroupsByKey;
+}
+
+function createHighestVersionGroupsByKey(
+    entries: readonly ChangelogEntryWithLabel[],
+    rule: HighestVersionCollapseRule
+): ReadonlyMap<string, HighestVersionCollapseGroup> {
+    return entries.reduce<ReadonlyMap<string, HighestVersionCollapseGroup>>(function (groupsByKey, entry, index) {
+        return updateHighestVersionGroupsByKey(groupsByKey, entry, index, rule);
+    }, new Map<string, HighestVersionCollapseGroup>());
 }
 
 function createCollapsedEntriesByIndex(
@@ -255,12 +378,43 @@ function createCollapsedEntriesByIndex(
     return [ collapsedEntries, skippedIndexes ];
 }
 
+function createHighestVersionCollapsedEntriesByIndex(
+    groupsByKey: ReadonlyMap<string, HighestVersionCollapseGroup>,
+    rule: HighestVersionCollapseRule
+): Readonly<[Map<number, ChangelogEntryWithLabel>, Set<number>]> {
+    const collapsedEntries = new Map<number, ChangelogEntryWithLabel>();
+    const skippedIndexes = new Set<number>();
+    const minimumGroupLength = 2;
+    const collapsedGroups = Array
+        .from(groupsByKey.values())
+        .filter(function (group) {
+            return group.indexes.length >= minimumGroupLength;
+        });
+
+    collapsedGroups.forEach(function (group) {
+        const [ , ...remainingIndexes ] = group.indexes;
+
+        collapsedEntries.set(group.firstIndex, {
+            title: renderCollapsedTitle(rule.replace, group.groups),
+            pullRequestIds: group.pullRequestIds,
+            label: rule.label
+        });
+
+        remainingIndexes.forEach(function (index) {
+            skippedIndexes.add(index);
+        });
+    });
+
+    return [ collapsedEntries, skippedIndexes ];
+}
+
 function collapseEntriesForRule(
     entries: readonly ChangelogEntryWithLabel[],
     rule: CollapseRule
 ): readonly ChangelogEntryWithLabel[] {
-    const chainsByKey = createChainsByKey(entries, rule);
-    const [ collapsedEntries, skippedIndexes ] = createCollapsedEntriesByIndex(chainsByKey, rule);
+    const [ collapsedEntries, skippedIndexes ] = isHighestVersionCollapseRule(rule)
+        ? createHighestVersionCollapsedEntriesByIndex(createHighestVersionGroupsByKey(entries, rule), rule)
+        : createCollapsedEntriesByIndex(createChainsByKey(entries, rule), rule);
 
     return entries.flatMap(function (entry, index) {
         if (skippedIndexes.has(index)) {

--- a/source/lib/pr-log-config-collapse-rules.test.ts
+++ b/source/lib/pr-log-config-collapse-rules.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert';
+import { createPrLogConfigFromPackageInfo } from './pr-log-config.ts';
+
+test('reads highest-version collapse rules from package info', function () {
+    const config = createPrLogConfigFromPackageInfo({
+        'pr-log': {
+            collapseRules: [
+                {
+                    label: 'upgrade',
+                    pattern: '^Update dependency (?<dependency>.+?) to (?<to>.+?)$',
+                    replace: 'Update dependency $<dependency> to $<to>',
+                    versionGroup: 'to'
+                }
+            ]
+        }
+    });
+
+    assert.deepStrictEqual(
+        config.collapseRules.map(function (collapseRule) {
+            return {
+                ...collapseRule,
+                pattern: collapseRule.pattern.source,
+                patternFlags: collapseRule.pattern.flags
+            };
+        }),
+        [
+            {
+                label: 'upgrade',
+                pattern: '^Update dependency (?<dependency>.+?) to (?<to>.+?)$',
+                patternFlags: 'u',
+                replace: 'Update dependency $<dependency> to $<to>',
+                keyGroup: 'dependency',
+                versionGroup: 'to'
+            }
+        ]
+    );
+});

--- a/source/lib/pr-log-config.ts
+++ b/source/lib/pr-log-config.ts
@@ -8,14 +8,23 @@ import {
 
 type PackageInfo = Readonly<Record<string, unknown>>;
 
-export type CollapseRule = {
+type CollapseRuleBase = {
     readonly label: string;
     readonly pattern: RegExp;
     readonly replace: string;
     readonly keyGroup: string;
+};
+
+export type VersionChainCollapseRule = CollapseRuleBase & {
     readonly fromGroup: string;
     readonly toGroup: string;
 };
+
+export type HighestVersionCollapseRule = CollapseRuleBase & {
+    readonly versionGroup: string;
+};
+
+export type CollapseRule = HighestVersionCollapseRule | VersionChainCollapseRule;
 
 export type PrLogConfig = {
     readonly validLabels: ReadonlyMap<string, string>;
@@ -101,12 +110,23 @@ function createCollapseRule(rule: Readonly<Record<string, unknown>>): CollapseRu
     const customKeyGroup = rule.keyGroup;
     const customFromGroup = rule.fromGroup;
     const customToGroup = rule.toGroup;
-
-    return {
+    const customVersionGroup = rule.versionGroup;
+    const baseRule = {
         label: getRequiredStringField(rule, 'label'),
         pattern: new RegExp(getRequiredStringField(rule, 'pattern'), 'u'),
         replace: getRequiredStringField(rule, 'replace'),
-        keyGroup: isString(customKeyGroup) ? customKeyGroup : 'dependency',
+        keyGroup: isString(customKeyGroup) ? customKeyGroup : 'dependency'
+    };
+
+    if (isString(customVersionGroup)) {
+        return {
+            ...baseRule,
+            versionGroup: customVersionGroup
+        };
+    }
+
+    return {
+        ...baseRule,
         fromGroup: isString(customFromGroup) ? customFromGroup : 'from',
         toGroup: isString(customToGroup) ? customToGroup : 'to'
     };

--- a/source/packages/command-line-interface/README.md
+++ b/source/packages/command-line-interface/README.md
@@ -91,7 +91,8 @@ Each collapse rule:
 - applies only to one label
 - matches pull request titles with a regular expression
 - groups entries by one named capture group
-- collapses only continuous chains where one entry ends with the version the next entry starts from
+- collapses continuous chains where one entry ends with the version the next entry starts from
+- can collapse entries without a previous version by selecting the highest semver capture group
 - renders the collapsed title with a replacement template
 
 ```json
@@ -121,6 +122,25 @@ become one changelog entry:
 The default capture group names are `dependency`, `from`, and `to`.
 If your title format uses different names, you can override them with `keyGroup`, `fromGroup`, and `toGroup`.
 Collapsed entries include links to all pull requests that contributed to the final line item.
+
+For title formats that only contain the new version, configure `versionGroup` instead of `fromGroup` and `toGroup`:
+
+```json
+{
+    "pr-log": {
+        "collapseRules": [
+            {
+                "label": "upgrade",
+                "pattern": "^Update dependency (?<dependency>.+?) to (?<to>.+?)$",
+                "replace": "Update dependency $<dependency> to $<to>",
+                "versionGroup": "to"
+            }
+        ]
+    }
+}
+```
+
+With that configuration, pr-log selects the highest semver value captured by `to` for each dependency.
 
 ## Usage
 

--- a/source/packages/core/README.md
+++ b/source/packages/core/README.md
@@ -65,6 +65,13 @@ const config = {
             keyGroup: 'dependency',
             fromGroup: 'from',
             toGroup: 'to'
+        },
+        {
+            label: 'change',
+            pattern: /^Update dependency (?<dependency>.+?) to (?<to>.+?)$/u,
+            replace: 'Update dependency $<dependency> to $<to>',
+            keyGroup: 'dependency',
+            versionGroup: 'to'
         }
     ],
     versionBumps: {


### PR DESCRIPTION
Adds an explicit `versionGroup` collapse mode for title formats that only include the new version. These rules group entries by `keyGroup`, render with the highest semver value captured by `versionGroup`, and keep existing `fromGroup` and `toGroup` chain rules unchanged.