### PR TITLE
Add `collapse: "same"` changelog collapse rules

### DIFF
--- a/source/lib/create-changelog-versionless-collapse.test.ts
+++ b/source/lib/create-changelog-versionless-collapse.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert';
+import { createChangelogFactory } from './create-changelog.ts';
+import { createPrLogConfigFromPackageInfo } from './pr-log-config.ts';
+import { createVersionNumber } from './version-number.ts';
+
+test('collapses repeated pull requests without version captures', function () {
+    const config = createPrLogConfigFromPackageInfo({
+        'pr-log': {
+            collapseRules: [
+                {
+                    label: 'upgrade',
+                    pattern: '^⬆️ Update (?<dependency>.+?)$',
+                    replace: '⬆️ Update $<dependency>',
+                    collapse: 'same'
+                }
+            ]
+        }
+    });
+    const createChangelog = createChangelogFactory({
+        getCurrentDate() {
+            return new Date(0);
+        },
+        config: {
+            ...config,
+            validLabels: new Map([ [ 'upgrade', 'Dependency Upgrades' ] ]),
+            versionBumps: { major: [], minor: [], patch: [ 'upgrade' ] }
+        }
+    });
+
+    const changelog = createChangelog({
+        unreleased: false,
+        versionNumber: createVersionNumber('1.0.0'),
+        githubRepo: 'any/repo',
+        mergedPullRequests: [
+            { id: 665, title: '⬆️ Update eslint', label: 'upgrade' },
+            { id: 660, title: '⬆️ Update @overkill-dev dependencies', label: 'upgrade' },
+            { id: 658, title: '⬆️ Update eslint', label: 'upgrade' },
+            { id: 650, title: '⬆️ Update Linting-related dependencies', label: 'upgrade' },
+            { id: 649, title: '⬆️ Update group:monorepos', label: 'upgrade' },
+            { id: 648, title: '⬆️ Update @overkill-dev dependencies', label: 'upgrade' },
+            { id: 647, title: 'Refresh dependency metadata', label: 'upgrade' }
+        ]
+    });
+
+    const expectedChangelog = [
+        '### Dependency Upgrades',
+        '',
+        '* ⬆️ Update eslint ([#665](https://github.com/any/repo/pull/665), [#658](https://github.com/any/repo/pull/658))',
+        '* ⬆️ Update @overkill-dev dependencies ([#660](https://github.com/any/repo/pull/660), [#648](https://github.com/any/repo/pull/648))',
+        '* ⬆️ Update Linting-related dependencies ([#650](https://github.com/any/repo/pull/650))',
+        '* ⬆️ Update group:monorepos ([#649](https://github.com/any/repo/pull/649))',
+        '* Refresh dependency metadata ([#647](https://github.com/any/repo/pull/647))',
+        ''
+    ]
+        .join('\n');
+
+    assert.ok(changelog.includes(expectedChangelog));
+});
+
+test('throws when a versionless collapse rule is missing the key capture group', function () {
+    const createChangelog = createChangelogFactory({
+        getCurrentDate() {
+            return new Date(0);
+        },
+        config: createPrLogConfigFromPackageInfo({
+            'pr-log': {
+                collapseRules: [
+                    {
+                        label: 'upgrade',
+                        pattern: '^⬆️ Update (?<dependency>.+?)$',
+                        replace: '⬆️ Update $<dependency>',
+                        keyGroup: 'name',
+                        collapse: 'same'
+                    }
+                ]
+            }
+        })
+    });
+
+    assert.throws(
+        function () {
+            createChangelog({
+                unreleased: false,
+                versionNumber: createVersionNumber('1.0.0'),
+                githubRepo: 'any/repo',
+                mergedPullRequests: [
+                    { id: 1, title: '⬆️ Update eslint', label: 'upgrade' }
+                ]
+            });
+        },
+        { message: 'Collapse rule for label "upgrade" requires capture group "name"' }
+    );
+});

--- a/source/lib/create-changelog.ts
+++ b/source/lib/create-changelog.ts
@@ -7,6 +7,7 @@ import type {
     CollapseRule,
     HighestVersionCollapseRule,
     PrLogConfig,
+    SameTitleCollapseRule,
     VersionChainCollapseRule
 } from './pr-log-config.ts';
 import type { ChangelogEntryInput } from './render-changelog-markdown.ts';
@@ -91,6 +92,10 @@ type HighestVersionRuleMatch = CollapseMatch & {
     readonly version: string;
 };
 
+type SameTitleRuleMatch = CollapseMatch & {
+    readonly key: string;
+};
+
 type CollapseChain = {
     readonly firstIndex: number;
     readonly indexes: readonly number[];
@@ -124,6 +129,10 @@ function createChangelogEntries(pullRequests: readonly ChangelogEntryInput[]): r
 
 function isHighestVersionCollapseRule(rule: CollapseRule): rule is HighestVersionCollapseRule {
     return Object.hasOwn(rule, 'versionGroup');
+}
+
+function isSameTitleCollapseRule(rule: CollapseRule): rule is SameTitleCollapseRule {
+    return Object.hasOwn(rule, 'collapse');
 }
 
 function getRuleKey(match: CollapseMatch, rule: CollapseRule): string {
@@ -204,6 +213,22 @@ function getHighestVersionRuleMatch(
     const version = getSemverGroup({ groups }, rule);
 
     return { key, version, groups };
+}
+
+function getSameTitleRuleMatch(
+    entry: ChangelogEntryWithLabel,
+    rule: SameTitleCollapseRule
+): SameTitleRuleMatch | undefined {
+    const match = rule.pattern.exec(entry.title);
+
+    if (match?.groups === undefined) {
+        return undefined;
+    }
+
+    const groups = { ...match.groups };
+    const key = getRuleKey({ groups }, rule);
+
+    return { key, groups };
 }
 
 function createExtendedChain(
@@ -347,6 +372,57 @@ function createHighestVersionGroupsByKey(
     }, new Map<string, HighestVersionCollapseGroup>());
 }
 
+function createSameTitleCollapseGroup(
+    index: number,
+    entry: ChangelogEntryWithLabel,
+    ruleMatch: SameTitleRuleMatch
+): CollapseChain {
+    return createCollapseChain(index, entry, ruleMatch.groups);
+}
+
+function extendSameTitleCollapseGroup(
+    group: CollapseChain,
+    entry: ChangelogEntryWithLabel,
+    index: number
+): CollapseChain {
+    return {
+        ...group,
+        indexes: [ ...group.indexes, index ],
+        pullRequestIds: [ ...group.pullRequestIds, ...entry.pullRequestIds ]
+    };
+}
+
+function updateSameTitleGroupsByKey(
+    groupsByKey: ReadonlyMap<string, CollapseChain>,
+    entry: ChangelogEntryWithLabel,
+    index: number,
+    rule: SameTitleCollapseRule
+): ReadonlyMap<string, CollapseChain> {
+    const ruleMatch = getSameTitleRuleMatch(entry, rule);
+
+    if (ruleMatch === undefined) {
+        return groupsByKey;
+    }
+
+    const nextGroupsByKey = new Map(groupsByKey);
+    const group = groupsByKey.get(ruleMatch.key);
+    const nextGroup = group === undefined
+        ? createSameTitleCollapseGroup(index, entry, ruleMatch)
+        : extendSameTitleCollapseGroup(group, entry, index);
+
+    nextGroupsByKey.set(ruleMatch.key, nextGroup);
+    return nextGroupsByKey;
+}
+
+function createSameTitleGroupsByKey(
+    entries: readonly ChangelogEntryWithLabel[],
+    rule: SameTitleCollapseRule
+): ReadonlyMap<string, CollapseChain> {
+    return entries.reduce<ReadonlyMap<string, CollapseChain>>(function (groupsByKey, entry, index) {
+        return updateSameTitleGroupsByKey(groupsByKey, entry, index, rule);
+    }, new Map<string, CollapseChain>());
+}
+
 function createCollapsedEntriesByIndex(
     chainsByKey: ReadonlyMap<string, readonly CollapseChain[]>,
     rule: CollapseRule
@@ -378,9 +454,9 @@ function createCollapsedEntriesByIndex(
     return [ collapsedEntries, skippedIndexes ];
 }
 
-function createHighestVersionCollapsedEntriesByIndex(
-    groupsByKey: ReadonlyMap<string, HighestVersionCollapseGroup>,
-    rule: HighestVersionCollapseRule
+function createGroupedCollapsedEntriesByIndex(
+    groupsByKey: ReadonlyMap<string, CollapseChain>,
+    rule: HighestVersionCollapseRule | SameTitleCollapseRule
 ): Readonly<[Map<number, ChangelogEntryWithLabel>, Set<number>]> {
     const collapsedEntries = new Map<number, ChangelogEntryWithLabel>();
     const skippedIndexes = new Set<number>();
@@ -408,13 +484,32 @@ function createHighestVersionCollapsedEntriesByIndex(
     return [ collapsedEntries, skippedIndexes ];
 }
 
+function createCollapseResultForRule(
+    entries: readonly ChangelogEntryWithLabel[],
+    rule: CollapseRule
+): Readonly<[Map<number, ChangelogEntryWithLabel>, Set<number>]> {
+    if (isSameTitleCollapseRule(rule)) {
+        return createGroupedCollapsedEntriesByIndex(
+            createSameTitleGroupsByKey(entries, rule),
+            rule
+        );
+    }
+
+    if (isHighestVersionCollapseRule(rule)) {
+        return createGroupedCollapsedEntriesByIndex(
+            createHighestVersionGroupsByKey(entries, rule),
+            rule
+        );
+    }
+
+    return createCollapsedEntriesByIndex(createChainsByKey(entries, rule), rule);
+}
+
 function collapseEntriesForRule(
     entries: readonly ChangelogEntryWithLabel[],
     rule: CollapseRule
 ): readonly ChangelogEntryWithLabel[] {
-    const [ collapsedEntries, skippedIndexes ] = isHighestVersionCollapseRule(rule)
-        ? createHighestVersionCollapsedEntriesByIndex(createHighestVersionGroupsByKey(entries, rule), rule)
-        : createCollapsedEntriesByIndex(createChainsByKey(entries, rule), rule);
+    const [ collapsedEntries, skippedIndexes ] = createCollapseResultForRule(entries, rule);
 
     return entries.flatMap(function (entry, index) {
         if (skippedIndexes.has(index)) {

--- a/source/lib/pr-log-config-collapse-rules.test.ts
+++ b/source/lib/pr-log-config-collapse-rules.test.ts
@@ -35,3 +35,58 @@ test('reads highest-version collapse rules from package info', function () {
         ]
     );
 });
+
+test('reads versionless collapse rules from package info', function () {
+    const config = createPrLogConfigFromPackageInfo({
+        'pr-log': {
+            collapseRules: [
+                {
+                    label: 'upgrade',
+                    pattern: '^⬆️ Update (?<dependency>.+?)$',
+                    replace: '⬆️ Update $<dependency>',
+                    collapse: 'same'
+                }
+            ]
+        }
+    });
+
+    assert.deepStrictEqual(
+        config.collapseRules.map(function (collapseRule) {
+            return {
+                ...collapseRule,
+                pattern: collapseRule.pattern.source,
+                patternFlags: collapseRule.pattern.flags
+            };
+        }),
+        [
+            {
+                label: 'upgrade',
+                pattern: '^⬆️ Update (?<dependency>.+?)$',
+                patternFlags: 'u',
+                replace: '⬆️ Update $<dependency>',
+                keyGroup: 'dependency',
+                collapse: 'same'
+            }
+        ]
+    );
+});
+
+test('throws when a collapse rule uses an unknown collapse mode', function () {
+    assert.throws(
+        function () {
+            createPrLogConfigFromPackageInfo({
+                'pr-log': {
+                    collapseRules: [
+                        {
+                            label: 'upgrade',
+                            pattern: '^⬆️ Update (?<dependency>.+?)$',
+                            replace: '⬆️ Update $<dependency>',
+                            collapse: 'latest'
+                        }
+                    ]
+                }
+            });
+        },
+        { message: 'pr-log.collapseRules[].collapse must be "same"' }
+    );
+});

--- a/source/lib/pr-log-config.ts
+++ b/source/lib/pr-log-config.ts
@@ -24,7 +24,11 @@ export type HighestVersionCollapseRule = CollapseRuleBase & {
     readonly versionGroup: string;
 };
 
-export type CollapseRule = HighestVersionCollapseRule | VersionChainCollapseRule;
+export type SameTitleCollapseRule = CollapseRuleBase & {
+    readonly collapse: 'same';
+};
+
+export type CollapseRule = HighestVersionCollapseRule | SameTitleCollapseRule | VersionChainCollapseRule;
 
 export type PrLogConfig = {
     readonly validLabels: ReadonlyMap<string, string>;
@@ -106,18 +110,38 @@ function getRequiredStringField(rule: Readonly<Record<string, unknown>>, fieldNa
     return value;
 }
 
-function createCollapseRule(rule: Readonly<Record<string, unknown>>): CollapseRule {
+function createCollapseRuleBase(rule: Readonly<Record<string, unknown>>): CollapseRuleBase {
     const customKeyGroup = rule.keyGroup;
-    const customFromGroup = rule.fromGroup;
-    const customToGroup = rule.toGroup;
-    const customVersionGroup = rule.versionGroup;
-    const baseRule = {
+
+    return {
         label: getRequiredStringField(rule, 'label'),
         pattern: new RegExp(getRequiredStringField(rule, 'pattern'), 'u'),
         replace: getRequiredStringField(rule, 'replace'),
         keyGroup: isString(customKeyGroup) ? customKeyGroup : 'dependency'
     };
+}
 
+function createSameTitleCollapseRule(
+    baseRule: CollapseRuleBase,
+    customCollapse: unknown
+): SameTitleCollapseRule | undefined {
+    if (customCollapse === 'same') {
+        return {
+            ...baseRule,
+            collapse: customCollapse
+        };
+    }
+    if (customCollapse !== undefined) {
+        throw new TypeError('pr-log.collapseRules[].collapse must be "same"');
+    }
+
+    return undefined;
+}
+
+function createHighestVersionCollapseRule(
+    baseRule: CollapseRuleBase,
+    customVersionGroup: unknown
+): HighestVersionCollapseRule | undefined {
     if (isString(customVersionGroup)) {
         return {
             ...baseRule,
@@ -125,11 +149,29 @@ function createCollapseRule(rule: Readonly<Record<string, unknown>>): CollapseRu
         };
     }
 
+    return undefined;
+}
+
+function createVersionChainCollapseRule(
+    baseRule: CollapseRuleBase,
+    rule: Readonly<Record<string, unknown>>
+): VersionChainCollapseRule {
+    const customFromGroup = rule.fromGroup;
+    const customToGroup = rule.toGroup;
+
     return {
         ...baseRule,
         fromGroup: isString(customFromGroup) ? customFromGroup : 'from',
         toGroup: isString(customToGroup) ? customToGroup : 'to'
     };
+}
+
+function createCollapseRule(rule: Readonly<Record<string, unknown>>): CollapseRule {
+    const baseRule = createCollapseRuleBase(rule);
+    const sameTitleRule = createSameTitleCollapseRule(baseRule, rule.collapse);
+    const highestVersionRule = createHighestVersionCollapseRule(baseRule, rule.versionGroup);
+
+    return sameTitleRule ?? highestVersionRule ?? createVersionChainCollapseRule(baseRule, rule);
 }
 
 function getCollapseRules(packageInfo: PackageInfo): readonly CollapseRule[] {

--- a/source/packages/command-line-interface/README.md
+++ b/source/packages/command-line-interface/README.md
@@ -93,6 +93,7 @@ Each collapse rule:
 - groups entries by one named capture group
 - collapses continuous chains where one entry ends with the version the next entry starts from
 - can collapse entries without a previous version by selecting the highest semver capture group
+- can collapse repeated entries without version captures
 - renders the collapsed title with a replacement template
 
 ```json
@@ -141,6 +142,26 @@ For title formats that only contain the new version, configure `versionGroup` in
 ```
 
 With that configuration, pr-log selects the highest semver value captured by `to` for each dependency.
+
+For grouped titles that contain no version, configure `collapse` as `same`:
+
+```json
+{
+    "pr-log": {
+        "collapseRules": [
+            {
+                "label": "upgrade",
+                "pattern": "^⬆️ Update (?<dependency>.+?)$",
+                "replace": "⬆️ Update $<dependency>",
+                "collapse": "same"
+            }
+        ]
+    }
+}
+```
+
+With that configuration, repeated titles such as `⬆️ Update eslint` are rendered once with all pull request links.
+The captured group can also include Renovate group names, such as `@overkill-dev dependencies`, `Linting-related dependencies`, or `group:monorepos`.
 
 ## Usage
 

--- a/source/packages/core/README.md
+++ b/source/packages/core/README.md
@@ -72,6 +72,13 @@ const config = {
             replace: 'Update dependency $<dependency> to $<to>',
             keyGroup: 'dependency',
             versionGroup: 'to'
+        },
+        {
+            label: 'change',
+            pattern: /^⬆️ Update (?<dependency>.+?)$/u,
+            replace: '⬆️ Update $<dependency>',
+            keyGroup: 'dependency',
+            collapse: 'same'
         }
     ],
     versionBumps: {


### PR DESCRIPTION
`collapse: "same"` lets collapse rules combine repeated titles that have no version captures, such as Renovate group updates. The engine groups matches by `keyGroup`, renders one replacement from that group, and preserves every pull request link.