### PR TITLE
Collapse short `@packtory/cli` update titles

### DIFF
--- a/packtory.config.js
+++ b/packtory.config.js
@@ -120,7 +120,7 @@ export async function buildConfig() {
     const versionedDependencyUpdatePattern =
         '^(?<prefix>⬆️ )?Update dependency (?<dependency>.+?) from (?<from>.+?) to (?<to>.+?)$';
     const singleVersionDependencyUpdatePattern =
-        '^(?<prefix>⬆️ )?Update dependency `?(?<dependency>.+?)`? to `?(?<to>[^` ]+)`?(?<from>)$';
+        '^(?<prefix>⬆️ )?Update (?:dependency )?`?(?<dependency>.+?)`? to `?(?<to>[^` ]+)`?(?<from>)$';
     const groupedDependencyUpdatePattern =
         '^(?<prefix>⬆️ )?(?<dependency>Lock file maintenance|Update (?:.+ dependencies|eslint))(?<from>)(?<to>)$';
 


### PR DESCRIPTION
Extends the temporary Packtory changelog workaround to match short dependency update titles without the `dependency` word. This lets the old bundled `pr-log` collapse titles like:

```text
Update `@packtory/cli` to `0.0.89`
```

into the existing `@packtory/cli` release line.