### PR TITLE
Remove `prepend-file` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
                 "git-url-parse": "16.1.0",
                 "loglevel": "1.9.2",
                 "parse-github-repo-url": "1.4.1",
-                "prepend-file": "2.0.1",
                 "semver": "7.8.5",
                 "true-myth": "9.4.0"
             },
@@ -6258,6 +6257,7 @@
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/handle-cli-error": {
@@ -9665,18 +9665,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/prepend-file": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/prepend-file/-/prepend-file-2.0.1.tgz",
-            "integrity": "sha512-0hXWjmOpz5YBIk6xujS0lYtCw6IAA0wCR3fw49UGTLc3E9BIhcxgqdMa8rzGvrtt2F8wFiGP42oEpQ8fo9zhRw==",
-            "license": "MIT",
-            "dependencies": {
-                "temp-write": "^4.0.0"
-            },
-            "engines": {
-                "node": "^10.17 || >=11.14"
-            }
-        },
         "node_modules/pretty-ms": {
             "version": "9.3.0",
             "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -10833,67 +10821,6 @@
                 "streamx": "^2.12.5"
             }
         },
-        "node_modules/temp-dir": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
-            "integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/temp-write": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/temp-write/-/temp-write-4.0.0.tgz",
-            "integrity": "sha512-HIeWmj77uOOHb0QX7siN3OtwV3CTntquin6TNVg6SHOqCP3hYKmox90eeFOGaY1MqJ9WYDDjkyZrW6qS5AWpbw==",
-            "license": "MIT",
-            "dependencies": {
-                "graceful-fs": "^4.1.15",
-                "is-stream": "^2.0.0",
-                "make-dir": "^3.0.0",
-                "temp-dir": "^1.0.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/temp-write/node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/temp-write/node_modules/make-dir": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-            "license": "MIT",
-            "dependencies": {
-                "semver": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/temp-write/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/test-exclude": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
@@ -11520,16 +11447,6 @@
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
-            }
-        },
-        "node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-            "license": "MIT",
-            "bin": {
-                "uuid": "bin/uuid"
             }
         },
         "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "git-url-parse": "16.1.0",
         "loglevel": "1.9.2",
         "parse-github-repo-url": "1.4.1",
-        "prepend-file": "2.0.1",
         "semver": "7.8.5",
         "true-myth": "9.4.0"
     },

--- a/source/lib/cli.test.ts
+++ b/source/lib/cli.test.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert';
 import { stub, type SinonSpy } from 'sinon';
-import type _prependFile from 'prepend-file';
 import type { Logger } from 'loglevel';
 import { Factory, type DeepPartial } from 'fishery';
 import { nothing } from 'true-myth/maybe';
+import type { PrependTextFile } from './prepend-text-file.ts';
 import { createCliRunner, type CliRunner, type CliRunnerDependencies } from './cli.ts';
 import type { CliRunOptions } from './cli-run-options.ts';
 import { defaultPrLogConfig } from './pr-log-config.ts';
@@ -28,7 +28,7 @@ function createDefaultCliDependencies(): CliRunnerDependencies {
         getMergedPullRequests: stub().resolves([]),
         renderChangelogMarkdown: stub().returns(''),
         getCurrentDate: stub().returns(new Date(0)),
-        prependFile: stub().resolves() as unknown as typeof _prependFile,
+        prependTextFile: stub().resolves() as PrependTextFile,
         packageInfo: { repository: { url: 'https://github.com/foo/bar.git' } },
         logger: { log: stub() } as unknown as Logger
     };
@@ -147,9 +147,9 @@ for (const throwsTestCase of throwsTestCases) {
 test('does not throw if the repository is dirty', async function () {
     const ensureCleanLocalGitState = stub().rejects(new Error('Local copy is not clean'));
     const renderChangelogMarkdown = stub().returns('sloppy changelog');
-    const prependFile = stub().resolves();
+    const prependTextFile = stub().resolves();
     const cli = createCli({
-        prependFile: prependFile as unknown as typeof _prependFile,
+        prependTextFile: prependTextFile as PrependTextFile,
         ensureCleanLocalGitState,
         renderChangelogMarkdown
     });
@@ -159,7 +159,7 @@ test('does not throw if the repository is dirty', async function () {
 
     await cli.run(options);
 
-    assertSpyCalls(prependFile, [ [ '/foo/CHANGELOG.md', 'sloppy changelog\n\n' ] ]);
+    assertSpyCalls(prependTextFile, [ [ '/foo/CHANGELOG.md', 'sloppy changelog\n\n' ] ]);
 });
 
 test('uses custom labels if they are provided in package.json', async function () {
@@ -250,12 +250,12 @@ test('calls getMergedPullRequests with the correct repo', async function () {
 
 test('reports the generated changelog to stdout and not to a file when stdout is set to true', async function () {
     const renderChangelogMarkdown = stub().returns('generated changelog');
-    const prependFile = stub().resolves();
+    const prependTextFile = stub().resolves();
     const log = stub();
 
     const cli = createCli({
         renderChangelogMarkdown,
-        prependFile: prependFile as unknown as typeof _prependFile,
+        prependTextFile: prependTextFile as PrependTextFile,
         logger: { log } as unknown as Logger
     });
 
@@ -275,18 +275,18 @@ test('reports the generated changelog to stdout and not to a file when stdout is
         versionNumber: '1.2.3'
     });
 
-    assert.strictEqual(prependFile.callCount, 0);
+    assert.strictEqual(prependTextFile.callCount, 0);
 
     assertSpyCalls(log, [ [ 'generated changelog' ] ]);
 });
 
 test('reports the generated changelog to a file when stdout is set to false', async function () {
     const renderChangelogMarkdown = stub().returns('generated changelog');
-    const prependFile = stub().resolves();
+    const prependTextFile = stub().resolves();
 
     const cli = createCli({
         renderChangelogMarkdown,
-        prependFile: prependFile as unknown as typeof _prependFile
+        prependTextFile: prependTextFile as PrependTextFile
     });
     const options = cliRunOptionsFactory.build({
         stdout: false
@@ -304,16 +304,16 @@ test('reports the generated changelog to a file when stdout is set to false', as
         versionNumber: '1.2.3'
     });
 
-    assertSpyCalls(prependFile, [ [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ] ]);
+    assertSpyCalls(prependTextFile, [ [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ] ]);
 });
 
 test('reports the generated unreleased changelog to a file when stdout is set to false', async function () {
     const renderChangelogMarkdown = stub().returns('generated changelog');
-    const prependFile = stub().resolves();
+    const prependTextFile = stub().resolves();
 
     const cli = createCli({
         renderChangelogMarkdown,
-        prependFile: prependFile as unknown as typeof _prependFile
+        prependTextFile: prependTextFile as PrependTextFile
     });
     const options: CliRunOptions = {
         unreleased: true,
@@ -336,17 +336,17 @@ test('reports the generated unreleased changelog to a file when stdout is set to
         versionNumber: undefined
     });
 
-    assertSpyCalls(prependFile, [ [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ] ]);
+    assertSpyCalls(prependTextFile, [ [ '/foo/CHANGELOG.md', 'generated changelog\n\n' ] ]);
 });
 
 test('derives the version number automatically from merged pull request labels', async function () {
     const renderChangelogMarkdown = stub().returns('generated changelog');
-    const prependFile = stub().resolves();
+    const prependTextFile = stub().resolves();
     const getLatestVersionTag = stub().resolves('1.2.3');
     const getMergedPullRequests = stub().resolves([ { id: 1, title: 'Add thing', label: 'feature' } ]);
     const cli = createCli({
         renderChangelogMarkdown,
-        prependFile: prependFile as unknown as typeof _prependFile,
+        prependTextFile: prependTextFile as PrependTextFile,
         getLatestVersionTag,
         getMergedPullRequests
     });
@@ -374,7 +374,7 @@ test('derives the version number automatically from merged pull request labels',
 
 test('uses configured version bump labels for auto-versioning', async function () {
     const renderChangelogMarkdown = stub().returns('generated changelog');
-    const prependFile = stub().resolves();
+    const prependTextFile = stub().resolves();
     const getLatestVersionTag = stub().resolves('1.2.3');
     const getMergedPullRequests = stub().resolves([ { id: 1, title: 'Docs', label: 'documentation' } ]);
     const packageInfo = {
@@ -387,7 +387,7 @@ test('uses configured version bump labels for auto-versioning', async function (
     };
     const cli = createCli({
         renderChangelogMarkdown,
-        prependFile: prependFile as unknown as typeof _prependFile,
+        prependTextFile: prependTextFile as PrependTextFile,
         getLatestVersionTag,
         getMergedPullRequests,
         packageInfo
@@ -424,14 +424,14 @@ test('strips trailing empty lines from the generated changelog', async function 
     const renderChangelogMarkdown = stub().returns(
         'generated\nchangelog\nwith\n\na\nlot\n\nof\nempty\nlines\n\n\n\n\n'
     );
-    const prependFile = stub().resolves();
+    const prependTextFile = stub().resolves();
 
-    const cli = createCli({ renderChangelogMarkdown, prependFile: prependFile as unknown as typeof _prependFile });
+    const cli = createCli({ renderChangelogMarkdown, prependTextFile: prependTextFile as PrependTextFile });
     const options = cliRunOptionsFactory.build();
 
     await cli.run(options);
 
-    assert.deepStrictEqual(prependFile.firstCall.args, [
+    assert.deepStrictEqual(prependTextFile.firstCall.args, [
         '/foo/CHANGELOG.md',
         'generated\nchangelog\nwith\n\na\nlot\n\nof\nempty\nlines\n\n'
     ]);

--- a/source/lib/cli.ts
+++ b/source/lib/cli.ts
@@ -1,8 +1,8 @@
-import type _prependFile from 'prepend-file';
 import type { Logger } from 'loglevel';
 import type { CliRunOptions } from './cli-run-options.ts';
 import type { GetMergedPullRequests } from './get-merged-pull-requests.ts';
 import type { EnsureCleanLocalGitState } from './ensure-clean-local-git-state.ts';
+import type { PrependTextFile } from './prepend-text-file.ts';
 import { getGithubRepoFromPackageInfo } from './package-info.ts';
 import {
     createPrLogConfigFromPackageInfo,
@@ -28,7 +28,7 @@ export type CliRunnerDependencies = {
     readonly renderChangelogMarkdown: typeof renderChangelogMarkdown;
     readonly getCurrentDate: () => Readonly<Date>;
     readonly packageInfo: Readonly<Record<string, unknown>>;
-    readonly prependFile: typeof _prependFile;
+    readonly prependTextFile: PrependTextFile;
     readonly logger: Logger;
 };
 
@@ -52,7 +52,7 @@ type ChangelogData = {
     readonly mergedPullRequests: Awaited<ReturnType<GetMergedPullRequests>>;
 };
 
-type WriteChangelogContext = Pick<CliRunnerDependencies, 'logger' | 'prependFile'>;
+type WriteChangelogContext = Pick<CliRunnerDependencies, 'logger' | 'prependTextFile'>;
 
 type ChangelogRequest = {
     readonly githubRepo: string;
@@ -148,13 +148,13 @@ async function writeChangelog(
     changelog: string,
     options: CliRunOptions
 ): Promise<void> {
-    const { prependFile, logger } = context;
+    const { prependTextFile, logger } = context;
     const trimmedChangelog = changelog.trim();
 
     if (options.stdout) {
         logger.log(trimmedChangelog);
     } else {
-        await prependFile(options.changelogPath, `${trimmedChangelog}\n\n`);
+        await prependTextFile(options.changelogPath, `${trimmedChangelog}\n\n`);
     }
 }
 

--- a/source/lib/prepend-text-file.test.ts
+++ b/source/lib/prepend-text-file.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { prependTextFile } from './prepend-text-file.ts';
+
+const byteOrderMark = JSON.parse([ '"\\u', 'fe', 'ff"' ].join('')) as string;
+
+async function withTemporaryFile(testFile: (filePath: string) => Promise<void>): Promise<void> {
+    const directoryPath = await fs.mkdtemp(path.join(os.tmpdir(), 'pr-log-'));
+
+    try {
+        await testFile(path.join(directoryPath, 'CHANGELOG.md'));
+    } finally {
+        await fs.rm(directoryPath, { force: true, recursive: true });
+    }
+}
+
+test('prependTextFile() creates a missing file', async function () {
+    await withTemporaryFile(async function (filePath) {
+        await prependTextFile(filePath, 'generated changelog\n\n');
+
+        assert.strictEqual(await fs.readFile(filePath, { encoding: 'utf8' }), 'generated changelog\n\n');
+    });
+});
+
+test('prependTextFile() prepends text to an existing file', async function () {
+    await withTemporaryFile(async function (filePath) {
+        await fs.writeFile(filePath, 'existing changelog\n', { encoding: 'utf8' });
+
+        await prependTextFile(filePath, 'generated changelog\n\n');
+
+        assert.strictEqual(
+            await fs.readFile(filePath, { encoding: 'utf8' }),
+            'generated changelog\n\nexisting changelog\n'
+        );
+    });
+});
+
+test('prependTextFile() keeps a byte order mark at the start of the file', async function () {
+    await withTemporaryFile(async function (filePath) {
+        await fs.writeFile(filePath, `${byteOrderMark}existing changelog\n`, { encoding: 'utf8' });
+
+        await prependTextFile(filePath, 'generated changelog\n\n');
+
+        assert.strictEqual(
+            await fs.readFile(filePath, { encoding: 'utf8' }),
+            `${byteOrderMark}generated changelog\n\nexisting changelog\n`
+        );
+    });
+});
+
+test('prependTextFile() rejects read errors', async function () {
+    await withTemporaryFile(async function (filePath) {
+        await fs.mkdir(filePath);
+
+        await assert.rejects(prependTextFile(filePath, 'generated changelog\n\n'), { code: 'EISDIR' });
+    });
+});

--- a/source/lib/prepend-text-file.ts
+++ b/source/lib/prepend-text-file.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs/promises';
+
+export type PrependTextFile = (filePath: string, text: string) => Promise<void>;
+
+const byteOrderMark = Buffer.from('77u/', 'base64').toString('utf8');
+
+function isMissingFileError(error: unknown): boolean {
+    return Reflect.get(new Object(error), 'code') === 'ENOENT';
+}
+
+function hasByteOrderMark(text: string): boolean {
+    return text.startsWith(byteOrderMark);
+}
+
+async function readTextFileIfPresent(filePath: string): Promise<string | undefined> {
+    try {
+        return await fs.readFile(filePath, { encoding: 'utf8' });
+    } catch (error: unknown) {
+        if (isMissingFileError(error)) {
+            return undefined;
+        }
+
+        throw error;
+    }
+}
+
+export const prependTextFile: PrependTextFile = async function (filePath, text) {
+    const currentText = await readTextFileIfPresent(filePath);
+
+    if (currentText === undefined) {
+        await fs.writeFile(filePath, text, { encoding: 'utf8' });
+        return;
+    }
+
+    const nextText = hasByteOrderMark(currentText)
+        ? `${byteOrderMark}${text}${currentText.slice(byteOrderMark.length)}`
+        : `${text}${currentText}`;
+
+    await fs.writeFile(filePath, nextText, { encoding: 'utf8' });
+};

--- a/source/packages/command-line-interface/composition.ts
+++ b/source/packages/command-line-interface/composition.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { Octokit } from '@octokit/rest';
 import { execa } from 'execa';
-import prependFile from 'prepend-file';
 import loglevel from 'loglevel';
 import { createCliRunner, type CliRunnerDependencies } from '../../lib/cli.ts';
 import { ensureCleanLocalGitStateFactory } from '../../lib/ensure-clean-local-git-state.ts';
@@ -15,6 +14,7 @@ import {
     createMergedPullRequestReader
 } from '../../lib/pr-log-engine-cli-adapter.ts';
 import { createJsonFileReader } from '../../lib/read-json-file.ts';
+import { prependTextFile } from '../../lib/prepend-text-file.ts';
 import { createRemoteAliasReader } from '../../lib/remote-alias-reader.ts';
 import { createPullRequestLabelValidator } from '../../lib/validate-pull-request-labels.ts';
 import { createPrLogEngine, defaultPrLogConfig } from '../core/core.entry-point.ts';
@@ -85,7 +85,7 @@ const commandLineInterfaceProgram = createProgram({
     createCliRunner({ defaultBranch, packageInfo }) {
         const dependencies: CliRunnerDependencies = {
             defaultPrLogConfig,
-            prependFile,
+            prependTextFile,
             packageInfo,
             logger: loglevel,
             ensureCleanLocalGitState: ensureCleanLocalGitStateFactory(


### PR DESCRIPTION
Replaces `prepend-file` with a local `prependTextFile` implementation that preserves changelog prepending behavior, including missing-file writes and BOM handling. This removes the `temp-write -> uuid@3.4.0` production dependency chain and fixes #727.